### PR TITLE
Add Perl scripts and READMEs of each directory

### DIFF
--- a/download_pubmed/README.md
+++ b/download_pubmed/README.md
@@ -1,0 +1,31 @@
+## `download_pubmed_` Folder
+
+This folder contains two Perl scripts that are responsible for downloading files from the NCBI ftp site.
+
+* `get_new_gene2pubmed.pl` - Downloads a zipped file that contains the mapping relationship between publications and genes
+* `get_pubmed_xml.pl` - Downloads all the zipped XML files (either from `baseline` or `updatefiles`) in PubMed. If any new zipped files are found, the files will be extracted
+
+
+### Example Usage
+
+**Download the latest gene2pubmed file**
+This script requires one parameter to be passed: `dir`. `dir` will tell the script where the file will be downloaded. 
+
+For example, the following command will download `gene2pubmed.gz` to a directory called `downloads`:
+
+```
+perl get_new_gene2pubmed.pl -dir downloads
+```
+
+**Download the latest PubMed XML files**
+This script require two parameters: `dir` and `type`. `dir` will tell the script where the files will be downloaded and extracted, `type` will dictate which XML will be downloaded. 
+
+For example, the following command will download all `/pubmed*.xml.gz` files from `updatefiles` into the `downloads/updatefiles` directory:
+
+```
+perl get_pubmed_xml.pl -dir downloads/updatefiles -type updatefiles
+```
+
+### Download Sources
+* [NCBI Gene Files](ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/)
+* [PubMed](ftp://ftp.ncbi.nlm.nih.gov/pubmed/)

--- a/download_pubmed/get_new_gene2pubmed.pl
+++ b/download_pubmed/get_new_gene2pubmed.pl
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+use Getopt::Long;
+use Pod::Usage;
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Downloads gene2pubmed File from NCBI
+#
+# One required parameter: a destination directory for the file download
+# 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+
+my $DIR;
+my $usage = "EXAMPLE USAGE
+$0 -dir <destination directory to save file> ";
+
+GetOptions(
+    'dir=s' => \$DIR,
+    help     => sub { pod2usage($usage); },
+) or pod2usage(2);
+
+unless ( $DIR ) {
+    pod2usage($usage);
+    pod2usage(2);
+}
+
+download_file( $DIR );
+unzip_file();
+say "Done.";
+
+
+#-----------------------
+# HELPER FUNCTIONS 
+#-----------------------
+
+sub download_file {
+    my ( $dir ) = @_;
+
+    chdir("$dir/") or 
+        say "Please enter valid directory name for dir" and exit;
+    system("rm -f wget_g2p.log");
+
+    #  -N: turn on time-stamping; only download if local timestamps are older
+    # -nv: show basic information (and error messages) only; no verbosity
+    my $cmd = 'wget -N -nv '
+        . 'ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2pubmed.gz '
+        . '2>> wget_g2p.log';
+    system( $cmd );
+}
+
+sub unzip_file  {
+    my $file =  "gene2pubmed.gz";
+    say "Unzipping and moving step $file";
+
+    my $cp_cmd = "cp -p $file $file.bak";
+    my $gz_cmd = "gunzip -f $file";
+    my $mv_cmd = "mv  $file.bak $file";
+
+    system( $cp_cmd );
+    system( $gz_cmd );
+    system( $mv_cmd );
+}

--- a/download_pubmed/get_pubmed_xml.pl
+++ b/download_pubmed/get_pubmed_xml.pl
@@ -1,0 +1,105 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+use Getopt::Long;
+use Pod::Usage;
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Downloads Baseline or Update Files from NCBI
+#
+# Two required parameters:
+#   - a destination directory for the files download
+#   - type of XMLs to download, either `baseline` or `updatefiles`
+# 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+my $DIR;
+my $TYPE;
+my $usage = "EXAMPLE USAGE
+$0 -dir <diretory name>  -type <'baseline' or 'updatefiles'>";
+
+GetOptions(
+    'dir=s' => \$DIR,
+    'type=s' =>\$TYPE,
+    help     => sub { pod2usage($usage); },
+) or pod2usage(2);
+
+unless ($DIR) {
+    pod2usage($usage);
+    pod2usage(2);
+}
+
+unless ($TYPE eq 'baseline' or $TYPE eq 'updatefiles' ){
+    pod2usage($usage);
+    pod2usage(2);
+}
+
+get_xml_files( $DIR, $TYPE );
+my $update_found = read_wget_log();
+if ( $update_found ) {
+    say "New updates found. Starting workflow to extract data from XMLs."
+}
+say "Done.";
+
+
+#-----------------------
+# HELPER FUNCTIONS 
+#-----------------------
+
+# Checks ftp site for XML files.
+sub get_xml_files {
+    my ( $dir, $type ) = @_;
+
+    chdir( "$dir/" ) or 
+        say "Please enter valid directory name for dir" and exit;
+    system("rm -f wget_updatefiles.log");
+
+    #  -N: turn on time-stamping; only download if local timestamps are older
+    # -nv: show basic information (and error messages) only; no verbosity
+    my $cmd = 'wget -N -nv '
+        . 'ftp://ftp.ncbi.nlm.nih.gov/pubmed/' . $type . '/pubmed*.xml.gz '
+        . '2>> wget_updatefiles.log';
+    system( $cmd );
+}
+
+
+# Read wget_updatefiles.log to see which files are updated, if any.
+sub read_wget_log {
+    open( LOG, '<', 'wget_updatefiles.log' ) or die $!;
+    my $update_found = 0;
+
+    while ( <LOG> ) {
+        chomp;
+
+        # Check if older files are same as files in "current_release".
+        if ( /(pubmed\w+\.xml\.gz).*-> "(.*)" \[/ ) {
+            $update_found = 1;
+
+            my $filename = $1;
+            my $status   = $2;
+            if ( $filename eq $status ) {
+                unzip_file( $filename );
+            }
+        }
+    }
+    return $update_found;
+}
+
+
+# Extract file without removing zipped file.
+sub unzip_file {
+    my ( $file ) = @_;
+
+    print "unzip file $file \n";
+
+    my $cp_cmd = "cp -p $file $file.bak";
+    my $gz_cmd = "gunzip -f $file";
+    my $mv_cmd = "mv $file.bak $file";
+
+    system( $cp_cmd );
+    system( $gz_cmd );
+    system( $mv_cmd );
+}
+

--- a/extract_pubmed/README.md
+++ b/extract_pubmed/README.md
@@ -1,0 +1,15 @@
+## `extract_pubmed` Folder
+
+This folder contains 8 Perl scripts that are responsible for extracting information from `gene2pubmed` and the publication XMLs into tabular-formatted files. These output files are used to update/populate the `biolitmine` database.
+
+* `create_mesh_files.pl` - Outputs two files: `mesh_info.txt` which contains information about each MeSH term; and `mesh_lookup.txt` which maps each parent MeSH term to their children.
+* `create_pi_files.pl` - Outputs two files: `pi2pubmed.txt` which lists all the authors of each publication; and `pi_info.txt` which contains information about each PI (including their number of total publications).
+* `filter_gene2pubmed.pl` - Filters through publications, keeping only those with a focus or is related to the study of model organisms and humans.
+* `find_cocitations.pl` - Outputs a file (`gene2gene.txt`) that maps and keeps tally of a gene that has been studied along with another gene in a publication.
+* `precompute_gene_pmids.pl` - Outputs a file (`gene_pmids.txt`) that maps a gene to a list of associated publications.
+* `precompute_mesh_pmids.pl`- Outputs a file (`mesh_pmids.txt`) that maps a MeSH ID to a list of associated publications. 
+* `precompute_mesh2gene.pl` - Outputs a file (`mesh2gene*.txt`) that maps a gene to a list of associated MeSH terms.
+* `precompute_path2pi.pl` - Outputs a file (`pathway2pi.txt`)
+
+**Note:**
+`precompute_mesh2gene.pl` has one optional parameter: `-child`. If passed, then the script will map a gene to a MeSH term along with all its child MeSH terms.

--- a/extract_pubmed/create_mesh_files.pl
+++ b/extract_pubmed/create_mesh_files.pl
@@ -1,0 +1,135 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Extract Information about Each MeSH Term from MeSH Trees of Interests:
+#     A - Anatomy
+#     B - Organisms
+#     C - Diseases
+#     D - Chemicals and Drugs
+#     E - Analytical, Diagnostic and Therapeutic Techniques, and Equipment
+#     F - Psychiatry and Psychology
+#     G - Phenomena and Processes
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+my $tree_numbers = '[ABCDEFG]';
+
+open( BRIEF, ">", 'data_input/mesh_files/mesh_info.txt' ) or die $!;
+open( LOOKUP, ">", 'data_input/mesh_files/mesh_lookup.txt' ) or die$!;
+local $, = "\t";
+
+my $mesh_data = 'data_input/mesh_files/current_mesh';
+open( MESH, "<", $mesh_data ) or die $!;
+
+# Use '*NEWRECORD' as EOL for easier file reading (ignore the "first" line afterward).
+local $/ = "*NEWRECORD\n";
+my $useless = <MESH>;
+
+my $tree_mapping;
+while (<MESH>) {
+
+    # MN - MeSH tree number(s)
+    # Note: because each record can have multiple MNs, regex will capture
+    #       all lines that contain 'MN =' then processes data accordingly.
+    #       It assumes that record format has 'PA' or 'MH_TH' after 'MN'
+    #       fields, and will use them as stopping point. Double-check file
+    #       if update is needed. 
+    my $mn = find_data( $_, '^(MN.*?)\n([^M]|MH_TH)' );
+    my $mns = get_list( 'MN = ', $mn );
+
+    # Move on if term is not in our trees of interest.
+    next unless scalar grep( /^$tree_numbers/, @$mns );
+
+    # MH - MeSH heading (main term)
+    my $mh = find_data( $_, '^MH = (.*?)\n' );
+
+    # UI - descriptor ID
+    my $ui = find_data( $_, '^UI = (.*?)\n' );
+    say BRIEF $ui, $mh, join( "; ", @$mns );
+
+    # Add tree numbers to do parent-child_mapping.
+    foreach my $mn ( @$mns ) {
+        $tree_mapping->{$mn} = $ui;
+    }
+
+    # ENTRY - entry term(s)
+    # Note: similar to MN, there can be multiple ENTRYs per record. Assumes
+    #       'MN' comes after 'ENTRY' fields.
+    my $entry = find_data( $_, '^(ENTRY.*?\n)^MN' );
+    my $entries = get_list( 'ENTRY = ', $entry );
+
+    # PRINT ENTRY - entry term(s), print form
+    # Note: again, there can be multiple PRINTs per record. Assumes 'ENTRY'
+    #       comes after 'PRINT ENTRY' fields.
+    my $print = find_data( $_, '^(PRINT ENTRY.*?\n)^ENTRY' );
+    my $prints = get_list( 'PRINT ENTRY = ', $print );
+
+    say LOOKUP $mh, $mh, 'MESH TERM';
+    foreach ( @$prints ) {
+        say LOOKUP $mh, $_, 'PRINT ENTRY TERM';
+    }
+    foreach ( @$entries ) {
+        say LOOKUP $mh, $_, 'ENTRY TERM';
+    } 
+}
+close MESH;
+close BRIEF;
+close LOOKUP;
+
+# Create file of parent desc IDs and their children desc IDs. List of children
+# also include grandchildren.
+open( TREE, '>', 'data_extracted/mesh_files/mesh_tree.txt' ) or die $!;
+my @numbers = keys %$tree_mapping;
+my %printed;
+foreach my $number ( @numbers ) {
+    my @children = grep( /^$number\./, @numbers );
+    next if @children == 0;
+
+    foreach my $child ( @children ) {
+        my $parent_desc = $tree_mapping->{$number};
+        my $child_desc = $tree_mapping->{$child};
+
+        # Only print parent-child mapping to output once.
+        $printed{$parent_desc . $child_desc}++;
+        if ( $printed{$parent_desc . $child_desc} == 1 ) {
+            say TREE $tree_mapping->{$number}, $tree_mapping->{$child};
+        }
+    }
+}
+close TREE;
+
+#-----------------------
+# HELPER FUNCTIONS 
+#-----------------------
+
+# Finds given regex in given record. Returns first captured group if 
+# pattern found, else returns 'Not found'.
+sub find_data {
+    my ( $record, $regex ) = @_;
+    if ( $record =~ /$regex/ms ) {
+        return $1;
+    }
+    else {
+        return 'Not found';
+    }
+}
+
+# Returns list of data after processing and splitting with given delim.
+sub get_list {
+    my ( $delim, $data ) = @_;
+
+    # Some entries may have subfields, e.g.
+    #     ENTRY = A-23187|T109|T195|LAB|NRW|NLM (1991)|900308|abbcdef
+    # so remove them, along with all newlines.
+    $data =~ s/\|.*?\n//g;
+    $data =~ s/\n//g;
+    my @list = split( $delim, $data );
+    shift @list; # first element is just '' so remove.
+    return \@list;
+}
+

--- a/extract_pubmed/create_pi_files.pl
+++ b/extract_pubmed/create_pi_files.pl
@@ -1,0 +1,142 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Extract Information about PIs
+#
+# In addition to contact information, keep a tally on number of genes studied 
+# in each publication.
+# 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+my $base_dir = 'data_extracted/combined/sorted/';
+my $gene2pubmed_dir = 'data_extracted/gene2pubmed/';
+
+# Get brief info of each PMID (publication/medline year, publication type).
+my %details;
+open( BRIEF, '<', $base_dir . 'brief_info.txt' ) or die $!;
+while (<BRIEF>) {
+    chomp;
+
+    # Skip header line (if any).
+    next if /^pmid\t/;
+    my ( 
+        $pmid, $title, $pub_date, $pub_year,
+        $med_date, $med_year, $type
+    ) = split "\t";
+    $pmid = trim($pmid);
+    $details{$pmid} = join( "\t", $pub_year, $med_year, $type );
+}
+close BRIEF;
+
+# Get PI info (last author) of each PMID.
+my %authors;
+open( AUTHOR, '<', $base_dir . 'authors2pubmed.txt' ) or die $!;
+while (<AUTHOR>) {
+    chomp;
+
+    # Skip header line (if any).
+    next if /^pmid\t/;
+    my (
+        $pmid, $lname, $fname,   $initials, $order, 
+        $last, $email, $address, $new_addr, $id
+    ) = split '\t';
+    if ( $last eq 'Y' ) {
+	    $pmid = trim($pmid);
+        $authors{$pmid} = join( "\t",   $lname, $fname, $initials,
+                                $email, $address );
+    }
+}
+close AUTHOR;
+
+# Process the files to find information about the authors.
+my ( %papers, %pis, %counts );
+open( G2P, '<', $gene2pubmed_dir. 'gene2pubmed_modified.txt' ) or die $!;
+while (<G2P>) {
+    chomp;
+    my ( $taxon, $gene, $pmid, $gene_count ) = split "\t";
+
+    # Only consider publications that study 100 genes or less.
+    next if $gene_count > 100;
+    
+    $pmid = trim($pmid);
+    
+    # Check if author data is available for the given PMID
+    if ( $authors{$pmid} and $details{$pmid} ) {
+        my ( $lname, $fname, $initials, $email, $addr ) = split "\t", $authors{$pmid};
+        my ( $pub_date, $med_date ) = split "\t", $details{$pmid};
+        my $composite_key = $gene . $lname . $initials;
+
+        # Keep list of PMIDs regarding gene for each PI.
+        if ( exists $papers{$composite_key} ) {
+            push @{$papers{$composite_key}}, $pmid;
+        }
+        else {
+            $papers{$composite_key} = [$pmid];
+        }
+
+        # Get most recent PMID of each PI, and its address and pub/med date. If there
+        # is no recent PMID, then this must be the first publication.
+        if ( exists $pis{$composite_key} ) {
+            my $recent_pmid = $pis{$composite_key}{recent};
+
+            if ( $pmid > $recent_pmid ) {
+                $pis{$composite_key}{recent} = $pmid;
+                $pis{$composite_key}{info} = join( "\t",
+                    $taxon, $gene, $lname, $initials, $addr, $pmid,
+                    ( $pub_date eq 'NA' ? $med_date : $pub_date )
+                );
+            }
+        }
+        else {
+            $pis{$composite_key} = {
+                recent => $pmid,
+                info => join( "\t", 
+                    $taxon, $gene, $lname, $initials, $addr, $pmid,
+                    ( $pub_date eq 'NA' ? $med_date : $pub_date )
+                )
+            };
+        }
+    }
+
+    # Keep record of each PMID's gene count.
+    $counts{$pmid} = $gene_count unless exists $counts{$pmid};
+}
+close G2P;
+
+# Print authors information of each publication, along with its gene count.
+open( REPORT, '>', $base_dir. 'pi2pubmed.txt' ) or die $!;
+say REPORT join( "\t",      'pmid',     'lname',    'fname',    'initials', 'email',
+                 'address', 'pub_year', 'med_year', 'pub_type', 'gene_count' );
+foreach my $pmid ( sort{ $a <=> $b } keys %counts ) {
+    next unless ( $authors{$pmid} and $details{$pmid} );
+    say REPORT join( "\t", $pmid, $authors{$pmid}, $details{$pmid}, $counts{$pmid} );
+}
+close REPORT;
+
+
+# Print PI information with precomputed list of PMIDs.
+open( REPORT, '>', $base_dir. 'pi_info.txt' ) or die $!;
+say REPORT join( "\t",         'tax_id', 'gene_id', 'lname', 'initials', 'address',
+                 'recent_pub', 'year',    'pmids',   'paper_count' );
+foreach my $pi ( keys %papers ) {
+    my @pmids = sort { $b <=> $a } @{ $papers{$pi} };
+    say REPORT $pis{$pi}{info}, "\t", join( ', ', @pmids ), "\t", scalar @pmids;
+}
+close REPORT;
+
+
+#-----------------------
+# HELPER FUNCTIONS 
+#-----------------------
+
+sub trim($) {
+    my $string = shift;
+    $string =~ s/^\s+//;
+    $string =~ s/\s+$//;
+    return $string;
+}

--- a/extract_pubmed/filter_gene2pubmed.pl
+++ b/extract_pubmed/filter_gene2pubmed.pl
@@ -1,0 +1,84 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Filter Publications
+#
+# Only keep publications focused on or related to the study of model organisms
+# and humans.
+# 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+my $taxons = [
+    3702,            #  1. thale cress
+    4896, 284812,    #  2. fission yeast
+    4932, 559292,    #  3. bakers yeast
+    6239,            #  4. worm
+    7227,            #  5. fruit fly
+    7955,            #  6. zebrafish
+    8364,            #  7. western clawed frog
+    9606,            #  8. human
+    10090,           #  9. mouse
+    10116            # 10. rat
+];
+
+filter_file( $taxons );
+my $gene_counts = find_unique_PMIDs();
+print_gene_counts( $gene_counts );
+
+
+#-----------------------
+# HELPER FUNCTIONS 
+#-----------------------
+
+sub filter_file {
+    my ( $taxons ) = @_;
+
+    foreach my $taxon ( @$taxons ) {
+        `egrep '^$taxon\\s' data_input/gene2pubmed >> data_extracted/gene2pubmed/gene2pubmed_filtered.txt`;
+    }
+}
+
+# Return list of "gene counts" index by PMID with count (# of times each PMID shows up).
+sub find_unique_PMIDs {
+    open( G2P, "<", "data_extracted/gene2pubmed/gene2pubmed_filtered.txt" ) or die $!;
+    open( UNIQ, ">", "data_extracted/gene2pubmed/gene2pubmed_uniq.txt" ) or die $!;
+
+    my %pmids;
+    my %species;
+    while (my $line = <G2P>) {
+        chomp $line;
+        my ( $taxon, $gene, $pmid ) = split /\t/, $line;
+        $taxon =~ s/284812/4896/;
+        $taxon =~ s/559292/4932/;
+        unless ( exists $species{$taxon}{$pmid} ) {
+            say UNIQ $line;
+            $species{$taxon}{$pmid}++;
+        }
+        $pmids{$pmid}++;
+    }
+    close G2P;
+    close UNIQ;
+
+    return \%pmids;
+}
+
+# Add "Gene Count" to records and re-print to "gene2pubmed_modified.txt".
+sub print_gene_counts {
+    my ( $counts ) = @_;
+    open( G2P, "<", "data_extracted/gene2pubmed/gene2pubmed_filtered.txt" ) or die $!;
+    open( OUTPUT, ">", "data_extracted/gene2pubmed/gene2pubmed_modified.txt" ) or die $!;
+
+    while (<G2P>) {
+        chomp;
+        my ( $tax, $gene, $pmid ) = split /\t/;
+        say OUTPUT join( "\t", $tax, $gene, $pmid, $counts->{$pmid} // "" );    
+    }
+    close G2P;
+    close OUTPUT;
+}
+

--- a/extract_pubmed/find_cocitations.pl
+++ b/extract_pubmed/find_cocitations.pl
@@ -1,0 +1,91 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+# 
+# Precompute Gene-Gene Co-citations
+# 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+
+my ( %pmids, %gene_info, %gene2gene );
+
+# Map gene ID to its gene symbol.
+open( GENE, '<', 'data_input/gene_information.csv' ) or die $!;
+while (<GENE>) {
+    chomp;
+    chop;  # to remove carriage return
+    my ( $gene_id, $taxon, $symbol ) = split ',';
+    $gene_info{$gene_id} = $symbol;
+}
+close GENE;
+
+# Consolidate list of gene IDs by PMID, skipping papers with >100 genes, e.g.
+#    Gene ID       PMID
+#    814631        10617197    ->    10617197 => [ 814631, 814636, 814642 ]
+#    814636        10617197
+#    814642        10617197
+open( G2P, '<', 'data_extracted/gene2pubmed/gene2pubmed_modified.txt' ) or die $!;
+while (<G2P>) {
+    chomp;
+    my ( $taxon, $gene, $pmid, $gene_count ) = split "\t";
+    next if $gene_count > 100;
+
+    if ( exists $pmids{$pmid} ) {
+        push @{$pmids{$pmid}}, $gene;
+    }
+    else {
+        $pmids{$pmid} = [$gene];
+    }
+}
+close G2P;
+
+# Create pairwise mapping of genes and their list of PMIDs, e.g.
+#     10617197 => [ 814631, 814636, 814642 ]
+#                     ↓
+#     gene1     gene2     list of PMIDs
+#     ------    ------    --------------
+#     814631 => 814636 => [ 10617197 ],
+#     814631 => 814642 => [ 10617197 ],
+#     814636 => 814642 => [ 10617197 ]
+foreach my $pmid ( keys %pmids ) {
+    my @genes = @{ $pmids{$pmid} };
+
+    for ( my $i = 0; $i < scalar @genes; $i++ ) {
+        for ( my $j = $i + 1; $j < scalar @genes; $j++ ) {
+            if ( exists $gene2gene{$genes[$i]}{$genes[$j]} ) {
+                push @{$gene2gene{$genes[$i]}{$genes[$j]}}, $pmid;
+            }
+            elsif ( exists $gene2gene{$genes[$j]}{$genes[$i]} ) {
+                push @{$gene2gene{$genes[$j]}{$genes[$i]}}, $pmid;
+            }
+            else {
+                $gene2gene{$genes[$i]}{$genes[$j]} = [$pmid];
+            }
+        }
+    }
+}
+
+# Print results to gene2gene.txt.
+open( OUTPUT, '>', 'data_extracted/precomputation/gene2gene.txt' ) or die $!;
+foreach my $gene1 ( keys %gene2gene ) {
+    # print "gene $gene1 \n";
+    foreach my $gene2 ( keys %{$gene2gene{$gene1}} ) {
+	#print "key $gene2 \n";
+        # Sorting in descending order so that latest PMID is listed first.
+        my @pmids = sort { $b <=> $a } @{ $gene2gene{$gene1}{$gene2}} ;
+        my $pmids = join( ', ', @pmids );
+        my $paper_count = scalar @pmids;
+
+        my $recent = $pmids;
+        $recent = join ( ', ', @pmids[0..9] ) if $paper_count > 10;
+        say OUTPUT join( "\t", 
+            $gene1,  $gene2, $gene_info{$gene2} // '',
+            $recent, $pmids, $paper_count 
+        );
+    }
+}
+close OUTPUT;
+

--- a/extract_pubmed/precompute_gene_pmids.pl
+++ b/extract_pubmed/precompute_gene_pmids.pl
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Precompute Mapping of Gene to List of PMIDs
+# 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+
+my $pmids;
+my $input_dir = "data_extracted/gene2pubmed/" ;
+my $output_dir = "data_extracted/precomputation/" ;
+
+system( "mkdir -p $output_dir" );
+
+open( INPUT, '<',  $input_dir . 'gene2pubmed_modified.txt' ) or die $!;
+while (<INPUT>) {
+	chomp;
+	my ( $taxon, $gene, $pmid ) = split "\t";
+	
+	if ( exists $pmids->{$gene} ) {
+		push @{$pmids->{$gene}}, $pmid;
+	}
+	else {
+		$pmids->{$gene} = [$pmid];
+	}
+}
+close INPUT;
+
+open( OUTPUT, '>', $output_dir . 'gene_pmids.txt' ) or die $!;
+foreach my $gene ( keys %$pmids ) {
+	my @pmids = sort { $b <=> $a } @{ $pmids->{$gene} };
+	say OUTPUT $gene, "\t", join(', ', @pmids ), "\t", scalar @pmids;
+}
+close OUTPUT;

--- a/extract_pubmed/precompute_mesh2gene.pl
+++ b/extract_pubmed/precompute_mesh2gene.pl
@@ -1,0 +1,269 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+use List::MoreUtils 'uniq';
+use POSIX 'log10';
+use Getopt::Long;
+use Pod::Usage;
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Precompute Mapping of Gene to List of MeSH IDs
+#
+# There is one optional parameter: if `-child` is passed, then precomputed mappings
+#                                  will include all child MeSH terms 
+#
+# TODO: 
+#   for gene2mesh, an additional "score" is used to sort the list of 
+#   MeSH terms for gene of interest. Current algorithm may not be the
+#   most correct so will need to be updated (lines 243-245).
+#
+#   Current algorithm:
+#     -log10(( gene-mesh papers / gene_papers ) * ( gene-mesh papers / mesh_papers ))
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+say "start";
+
+# GLOBALS. Optional mapping of including child terms.
+my $CHILD = '';
+my $usage = "Usage:
+  $0 [-child]
+
+Quick Help:
+  -child    precompute mappings to include child terms";
+
+# Check flags.
+GetOptions (
+    'child' => \$CHILD,
+    'help'  => sub { pod2usage($usage) }
+) or pod2usage(2);
+
+my ( $gene_info, $mesh_info, $pmid2mesh, $pmid2gene, $children, $final, $count );
+my $input_dir = "." ;
+my $output_dir = "data_extracted/precomputation/" ;
+my $download_mesh_dir = "data_input/mesh_files/" ;
+
+# Map gene ID to its gene symbol and total number of PMIDs.
+say ".2. ";
+open( GENE, '<', 'data_input/gene_information.csv' ) or die $!;
+while (<GENE>) {
+    chomp;
+    chop;  # to remove carriage return
+    my ( $gene_id, $taxon, $symbol ) = split ',';
+    $gene_id = trim($gene_id);
+    $symbol = trim($symbol);
+    $gene_info->{$gene_id}{symbol} = $symbol;
+}
+close GENE;
+
+say ".3. ";
+open( GENE, '<', $output_dir. 'gene_pmids.txt' ) or die $!;
+while (<GENE>) {
+    chomp;
+    my ( $gene_id, $pmids, $count ) = split "\t";
+    $gene_id = trim($gene_id);
+    $count = trim($count);
+    $gene_info->{$gene_id}{paper_count} = $count;
+}
+close GENE;
+
+
+# Map desc ID to its MeSH heading and total number of PMIDs.
+say ".4. ";
+open( MESH, '<',  $download_mesh_dir. 'mesh_info.txt' ) or die $!;
+while (<MESH>) {
+    chomp;
+    my ( $desc_id, $term ) = split "\t";
+    $term = trim($term);
+    $desc_id = trim($desc_id);
+    $mesh_info->{$desc_id}{term} = $term;
+}
+close MESH;
+
+say ".5. ";
+open( MESH, '<', $output_dir. 'mesh_pmids.txt' ) or die $!;
+while (<MESH>) {
+    chomp;
+    my ( $desc_id, $pmids, $count ) = split "\t";
+    $desc_id = trim($desc_id);
+    $count = trim($count);
+    next unless exists $mesh_info->{$desc_id};
+    $mesh_info->{$desc_id}{paper_count} = $count;
+}
+close MESH;
+
+
+# Map PMID to its list of MeSH terms
+open( MESH, '<',  'data_extracted/combined/sorted/mesh2pubmed.txt' ) or die $!;
+while (<MESH>) {
+    chomp;
+    my ( $pmid, $desc ) = split "\t";
+    $desc = trim($desc);
+    $pmid = trim($pmid);
+
+    if ( exists $pmid2mesh->{$pmid} ) {
+        push @{$pmid2mesh->{$pmid}}, $desc;
+    }
+    else {
+        $pmid2mesh->{$pmid} = [$desc];
+    }
+}
+close MESH;
+
+
+# Map PMID to its list of gene IDs
+say ".6. ";
+open( GENE, '<', 'data_extracted/gene2pubmed/gene2pubmed_modified.txt' ) or die $!;
+while (<GENE>) {
+    chomp;
+    my ( $taxon, $gene, $pmid, $count ) = split "\t";
+
+    $taxon = trim($taxon);
+    $pmid = trim($pmid);
+    $count = trim($count);
+    $gene = trim($gene);
+
+    #??? amc
+    #next if $count > 100;
+
+    if ( exists $pmid2gene->{$pmid} ) {
+        push @{$pmid2gene->{$pmid}}, join( ',', $taxon, $gene );
+    }
+    else {
+        $pmid2gene->{$pmid} = [join( ',', $taxon, $gene )];
+    }
+}
+close GENE;
+
+# If 'child' option is enabled, create mapping of parent MeSH
+# terms to all their child terms, e.g.
+#     parent        child
+#     D017918        D017919
+#     D017918        D006515
+if ( $CHILD ) {
+    open( TREE, '<', 'data_extracted/mesh_files/mesh_tree.txt' ) or die $!;
+    while(<TREE>) {
+        chomp;
+        my ( $parent, $child ) = split "\t";
+
+        if ( exists $children->{$child} ) {
+            push @{$children->{$child}}, $parent;
+        }
+        else {
+            $children->{$child} = [$parent];
+        }
+    }
+    close TREE;
+}
+
+
+# Create final mapping of mesh2gene and their full list of PMIDs.
+my $printcount = 0;
+foreach my $pmid_temp ( sort { $b <=> $a } keys %$pmid2mesh ) {
+    chomp;
+    my $pmid = "" . $pmid_temp;
+    $printcount++;
+    
+    if ( $printcount < 1000 ) {
+	    say "pmid2gene $pmid";
+    }
+
+    # does the gene have a PMID associated with it?
+    if ( exists $pmid2gene->{$pmid} ) {
+        if ( $printcount < 10 ){
+            say $pmid ." -> exists";
+        }
+        
+        # Get the genes and mesh terms for a given PMID
+        my @terms = @{ $pmid2mesh->{$pmid} };
+        my @genes = @{ $pmid2gene->{$pmid} };
+
+        foreach my $desc ( @terms ) {
+
+            if ( $printcount < 10 ){
+                say "  --- $desc";
+            }
+
+            foreach my $gene ( @genes ) {
+
+                if ( $printcount < 10 ){
+                    print "  --- - -  $gene";
+                }
+
+                if ( exists $final->{$desc}{$gene} ) {
+                    push @{$final->{$desc}{$gene}}, $pmid;
+                } else {
+                    $final->{$desc}{$gene} = [$pmid];
+                }
+                if ( $CHILD and exists $children->{$desc} ) {
+                    foreach my $parent ( @{ $children->{$desc} } ) {
+                        if ( exists $final->{$parent}{$gene} ) {
+                            push @{$final->{$parent}{$gene}}, $pmid;
+                        }
+                        else {
+                            $final->{$parent}{$gene} = [$pmid];
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+# Print results for upload into file for later import into database.
+my $output = $CHILD ? 'mesh2gene_parent.txt' : 'mesh2gene.txt';
+$output = $output_dir . $output;
+say "output file " . $output;
+
+open( OUTPUT, '>', $output ) or die $!;
+foreach my $desc ( keys %$final ) {
+    if (ref $final->{$desc} eq 'HASH'){
+
+	foreach my $gene (keys  %{$final->{$desc}}) {
+	    my ( $taxon, $id ) = split ',', $gene;
+
+	    my @pmids = @{ $final->{$desc}{$gene} };
+	    @pmids = uniq ( sort { $b <=> $a } @pmids );
+	    my $pmids = join( ', ', @pmids );
+	    my $count = () = $pmids =~ /,/g;
+	    $count++;
+
+	    # UI is only showing, at most, 10 recent publications. Truncate if needed.
+	    my $recent = $pmids;
+	    $recent = join( ', ', @pmids[0..9] ) if $count > 10;
+
+	    # Only print mesh2gene mappings with MeSH terms we want, i.e. 
+	    # D057229 ("Poverty") is not relevant so will not print.
+	    if ( exists $gene_info->{$id}{paper_count} and scalar keys %{ $mesh_info->{$desc} } == 2 ) {
+	    
+            # Calculate score. 
+            my $gene_freq = ( $count / $gene_info->{$id}{paper_count} );
+            my $mesh_freq = ( $count / $mesh_info->{$desc}{paper_count} );
+            my $score = sprintf( '%.2f', log10( $gene_freq * $mesh_freq ) * -1 );
+        
+            say OUTPUT join( "\t", 
+                     $taxon, $desc, $mesh_info->{$desc}{term}, $id, 
+                     ( $gene_info->{$id}{symbol} // '' ), $recent, 
+                     $pmids, $count, $score 
+                );
+            }
+        }
+    }
+}
+close OUTPUT;
+
+
+#-----------------------
+# HELPER FUNCTIONS 
+#-----------------------
+
+sub trim($)
+{
+    my $string = shift;
+    $string =~ s/^\s+//;
+    $string =~ s/\s+$//;
+    return $string;
+}

--- a/extract_pubmed/precompute_mesh_pmids.pl
+++ b/extract_pubmed/precompute_mesh_pmids.pl
@@ -1,0 +1,41 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Precompute Mapping of MeSH ID to List of PMIDs
+# 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+my $pmids;
+
+
+my $input_dir = "data_extracted/combined/sorted/" ;
+my $output_dir = "data_extracted/precomputation/" ;
+
+# pmid	mesh
+# 1		D000432
+open( INPUT, '<', $input_dir.  'mesh2pubmed.txt' ) or die $!;
+while (<INPUT>) {
+	chomp;
+	my ( $pmid, $mesh ) = split "\t";
+	
+	if ( exists $pmids->{$mesh} ) {
+		push @{$pmids->{$mesh}}, $pmid;
+	}
+	else {
+		$pmids->{$mesh} = [$pmid];
+	}
+}
+close INPUT;
+
+open( OUTPUT, '>', $output_dir. 'mesh_pmids.txt' ) or die $!;
+foreach my $mesh ( keys %$pmids ) {
+	my @pmids = sort { $b <=> $a } @{ $pmids->{$mesh} };
+	say OUTPUT $mesh, "\t", join(', ', @pmids ), "\t", scalar @pmids;
+}
+close OUTPUT;
+

--- a/extract_pubmed/precompute_path2pi.pl
+++ b/extract_pubmed/precompute_path2pi.pl
@@ -1,0 +1,114 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use feature 'say';
+use List::MoreUtils 'uniq';
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Precompute Mapping of PMIDs to PIs
+#
+# NOTE: each PI is someone who studied pathway-related genes
+# 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+my ( $pathways, $pi_info, $final );
+
+my $input ="data_extracted/combined/sorted/";
+my $output_dir = "data_extracted/precomputation/" ;
+my $download_dir = "data_input/";
+
+open( PATH, '<', $download_dir.'TM_pathways.csv' ) or die $!;
+while (<PATH>) {
+    chomp;
+
+    # Remove all quotations.
+    s/"//g;
+    my ( 
+        $id, $taxon, $gene_id, $symbol, 
+        $gene_name, $uniprot, $pathway 
+    ) = split "\t";
+
+    my $composite_key = $taxon . ';' . $pathway;
+    if ( exists $pathways->{$composite_key} ) {
+        push @{$pathways->{$composite_key}}, $gene_id . ';' . $symbol;
+    }
+    else {
+        $pathways->{$composite_key} = [$gene_id . ';' . $symbol];
+    }
+}
+close PATH;
+
+open( PI, '<', $input . 'pi_info.txt' ) or die $!;
+while (<PI>) {
+    chomp;
+    my ( 
+        $taxon, $gene, $lname, $initials, 
+        $address, $recent, $year, $pmids
+    ) = split "\t";
+
+    my $pi = $lname . ', ' . $initials;
+    $pi_info->{$gene}{$pi} = {
+        recent => $recent,
+        info => join( "\t", $address, $recent, $year ),
+        pmids => [ split( ', ', $pmids ) ]
+    };
+}
+close PI;
+
+# Map pathway to PI, and include list of pathway-related genes and
+# associating PMIDs (by PI).
+foreach my $pathway ( keys %$pathways ) {
+    foreach my $gene ( @{ $pathways->{$pathway} } ) {
+        my ( $id, $symbol ) = split ';', $gene;
+
+        # Skip if no PI info can be found for gene.
+        next unless exists $pi_info->{$id};
+
+        foreach my $pi ( keys %{$pi_info->{$id}} ) {
+            if ( exists $final->{$pathway}{$pi} ) {
+                push @{$final->{$pathway}{$pi}{genes}}, $symbol;
+
+                # Add PMIDs to current list for PI. Re-sort list and remove
+                # duplicates.
+                my @pmids = @{ $final->{$pathway}{$pi}{pmids} };
+                my @new_pmids = @{ $pi_info->{$id}{$pi}{pmids} };
+                push @pmids, @new_pmids;
+                @pmids = uniq ( sort { $b <=> $a } @pmids );
+		        $final->{$pathway}{$pi}{pmids} = \@pmids;
+
+                # If gene's recent paper is more recent than one currently
+                # listed for PI, replace with updated info.
+                if ( $final->{$pathway}{$pi}{recent} < $pi_info->{$id}{$pi}{recent} ) {
+                    $final->{$pathway}{$pi}{recent} = $pi_info->{$id}{$pi}{recent};
+                    $final->{$pathway}{$pi}{info} = $pi_info->{$id}{$pi}{info};
+                }
+            }
+            else {
+                $final->{$pathway}{$pi} = {
+                    genes => [$symbol],
+                    recent => $pi_info->{$id}{$pi}{recent},
+                    pmids => $pi_info->{$id}{$pi}{pmids},
+                    info => $pi_info->{$id}{$pi}{info}
+                };
+            }
+        }
+    }
+}
+
+# Output results to output file for upload into DB.
+open( OUTPUT, '>', $output_dir . 'pathway2pi.txt' ) or die $!;
+foreach my $pathway ( keys %$final ) {
+    my ( $taxon, $name ) = split ';', $pathway;
+    foreach my $pi ( keys %{$final->{$pathway}} ) {
+        my @genes = uniq @{ $final->{$pathway}{$pi}{genes} };
+        my @pmids =  @{$final->{$pathway}{$pi}{pmids}} ;
+        say OUTPUT join( "\t", 
+            $taxon, $name, $pi, $final->{$pathway}{$pi}{info},
+            join(', ', @genes ), scalar @genes,  
+            join( ', ', @pmids ), scalar @pmids
+        );
+    }
+}
+close OUTPUT;


### PR DESCRIPTION
The Perl scripts have been divided into two directories: `download_pubmed` and `extract_pubmed`. READMEs have been written for both directories, describing the purpose of each script within the folder.

One thing to note:
I have removed the lines of code that would email and notify the bioinformatics team regarding file updates from the `get_new_gene2pubmed.pl` and `get_pubmed_xml.pl` scripts.